### PR TITLE
fix: No Provider for injector

### DIFF
--- a/projects/iplab/ngx-file-upload/src/lib/file-upload.module.ts
+++ b/projects/iplab/ngx-file-upload/src/lib/file-upload.module.ts
@@ -66,11 +66,5 @@ export { FileUploadService } from './services/file-upload.service';
     ]
 })
 export class FileUploadModule {
-
-    constructor(private injector: Injector) {
-        // const fileUploadElement = createCustomElement(FileUploadComponent, { injector });
-        // customElements.define('file-upload', fileUploadElement);
-    }
-
     ngDoBootstrap() {}
 }


### PR DESCRIPTION
this fixes the issue when `npm link` two projects with one of them importing uploader module